### PR TITLE
Adapt tslint and prettier config to match existing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
 node_modules
+out
 .vscode-test/
 *.vsix

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "printWidth": 120,
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": false
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin"
+		"ms-vscode.vscode-typescript-tslint-plugin",
+		"esbenp.prettier-vscode"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: watch"
+			"preLaunchTask": "npm: webpack-dev"
 		},
 		{
 			"name": "Extension Tests",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2049,8 +2049,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2071,14 +2070,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2093,20 +2090,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2223,8 +2217,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2236,7 +2229,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2251,7 +2243,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2259,14 +2250,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2285,7 +2274,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2366,8 +2354,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2379,7 +2366,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2465,8 +2451,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2502,7 +2487,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2522,7 +2506,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2566,14 +2549,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4042,6 +4023,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prettier": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
 			"dev": true
 		},
 		"process": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@types/vscode": "^1.39.0",
 		"glob": "^7.1.5",
 		"mocha": "^6.2.2",
+		"prettier": "^1.18.2",
 		"ts-loader": "^6.2.1",
 		"tslint": "^5.12.1",
 		"typescript": "^3.7.2",

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -32,7 +32,9 @@ export interface ArcMessage {
   // arc typically ignores lines that were not edited, this bypasses that
   bypassChangedLineFiltering: boolean | null;
 }
-interface ArcJSON { [filename: string]: ArcMessage[] }
+interface ArcJSON {
+  [filename: string]: ArcMessage[];
+}
 
 export async function runArcDiff(fileName: string): Promise<ArcMessage[]> {
   const bin = config.pathToArc;
@@ -49,7 +51,9 @@ export async function runArcDiff(fileName: string): Promise<ArcMessage[]> {
 
 function getArcMessageForFile(json: ArcJSON, fileName: string): ArcMessage[] {
   const fileNames = Object.keys(json);
-  const key = fileNames.find((f) => fileName.endsWith(f));
-  if (!key) { throw new Error(`${fileName} not found in: ${fileNames.join(", ")}`); }
+  const key = fileNames.find(f => fileName.endsWith(f));
+  if (!key) {
+    throw new Error(`${fileName} not found in: ${fileNames.join(", ")}`);
+  }
   return json[key];
 }

--- a/src/code_provider.ts
+++ b/src/code_provider.ts
@@ -23,15 +23,21 @@ export default class ArcCodeActionsProvider implements CodeActionProvider {
     const actions = [];
     for (const m of messages) {
       const action = this.createAction(m, document);
-      if (action) { actions.push(action); }
+      if (action) {
+        actions.push(action);
+      }
     }
-    if (context.only) { return actions.filter((a) => a.kind === context.only); }
+    if (context.only) {
+      return actions.filter(a => a.kind === context.only);
+    }
     return actions;
   }
 
   public createAction(m: Message, document: TextDocument): CodeAction | undefined {
     const edit = m.edit;
-    if (!edit) { return; }
+    if (!edit) {
+      return;
+    }
     const original = document.getText(m.range);
     if (original !== m.arcMessage.original) {
       debug(`Text changed:\nA: ${inspect(original)}\nB: ${inspect(m.arcMessage.original)}`);

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -3,10 +3,14 @@ import { OutputChannel, window } from "vscode";
 import config from "./config";
 
 export function debug(o: any) {
-  if (config.debug) { log(o); }
+  if (config.debug) {
+    log(o);
+  }
 }
 export function log(o: any) {
-  if (!log._logger) { log._logger = window.createOutputChannel("Arcanist"); }
+  if (!log._logger) {
+    log._logger = window.createOutputChannel("Arcanist");
+  }
   log._logger.appendLine(typeof o === "string" ? o : inspect(o));
 }
 log._logger = undefined as OutputChannel | undefined;

--- a/src/edit_provider.ts
+++ b/src/edit_provider.ts
@@ -29,14 +29,18 @@ export default class ArcFormattingEditProvider implements DocumentFormattingEdit
       if (document.isDirty) {
         debug("saving before editing");
         await document.save();
-        if (token.isCancellationRequested) { return []; }
+        if (token.isCancellationRequested) {
+          return [];
+        }
       }
 
       const output = await runArcDiff(fileName);
-      if (token.isCancellationRequested) { return []; }
+      if (token.isCancellationRequested) {
+        return [];
+      }
 
       const messages = output
-        .map((m) => {
+        .map(m => {
           try {
             return new Message(m, document);
           } catch (err) {
@@ -51,8 +55,11 @@ export default class ArcFormattingEditProvider implements DocumentFormattingEdit
       const errors = [];
       for (const m of messages) {
         const edit = m.edit;
-        if (edit && m.arcMessage.severity === "autofix") { edits.push(edit); }
-        else { errors.push(m); }
+        if (edit && m.arcMessage.severity === "autofix") {
+          edits.push(edit);
+        } else {
+          errors.push(m);
+        }
       }
 
       diags.set(document.uri, errors);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,5 +14,3 @@ export function activate(context: ExtensionContext) {
     languages.registerCodeActionsProvider({ scheme: "file" }, new ArcCodeActionsProvider()),
   );
 }
-
-export function deactivate() {}

--- a/src/message.ts
+++ b/src/message.ts
@@ -3,8 +3,12 @@ import { ArcMessage } from "./arc";
 
 export default class Message extends Diagnostic {
   get patchText() {
-    if (!this.arcMessage.replacement) { return; }
-    if (this.arcMessage.replacement === this.arcMessage.original) { return; }
+    if (!this.arcMessage.replacement) {
+      return;
+    }
+    if (this.arcMessage.replacement === this.arcMessage.original) {
+      return;
+    }
     return this.arcMessage.replacement;
   }
   get actionKind() {
@@ -12,23 +16,35 @@ export default class Message extends Diagnostic {
   }
   get edit() {
     const patchText = this.patchText;
-    if (patchText === undefined) { return; }
+    if (patchText === undefined) {
+      return;
+    }
     return new TextEdit(this.range, patchText);
   }
   public static getRange({ char, line, original }: ArcMessage, document: TextDocument): Range {
     line = line || 0; // it can return null
-    if (char === null || original === null) { return document.lineAt(line).range; }
+    if (char === null || original === null) {
+      return document.lineAt(line).range;
+    }
     const lines = original.split("\n");
     const endLine = line + lines.length - 2;
     const endChar = lines[lines.length - 1].length;
     return new Range(line - 1, char - 1, endLine, endChar);
   }
   public static getSeverity({ severity }: ArcMessage): DiagnosticSeverity {
-    if (severity === "warning") { return DiagnosticSeverity.Warning; }
-    if (severity === "autofix") { return DiagnosticSeverity.Information; }
-    if (severity === "advice") { return DiagnosticSeverity.Information; }
+    if (severity === "warning") {
+      return DiagnosticSeverity.Warning;
+    }
+    if (severity === "autofix") {
+      return DiagnosticSeverity.Information;
+    }
+    if (severity === "advice") {
+      return DiagnosticSeverity.Information;
+    }
     // TODO: maybe disable this instead?
-    if (severity === "disabled") { return DiagnosticSeverity.Information; }
+    if (severity === "disabled") {
+      return DiagnosticSeverity.Information;
+    }
     return DiagnosticSeverity.Error;
   }
   public arcMessage: ArcMessage;

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,7 @@
 {
 	"extends": "tslint:recommended",
-	"rules": {}
+	"rules": {
+		"arrow-parens": false,
+		"interface-name": false
+	}
 }


### PR DESCRIPTION
Since this isn't built inside an `arc` workspace, I formatted everything with Prettier and adjusted the tslint and prettierrc to match the existing style as much as possible. Prettier is still pretty aggressive when it comes to unwrapping 1-liners though. Alternatively, we could create an `arc lint` config for this and have it format itself?

Also adjusted launch.json to allow debugging.